### PR TITLE
Pass LMGC90_GIT_URL secret into docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   docs:
     runs-on: ubuntu-latest
+    env:
+      LMGC90_GIT_URL: ${{ secrets.LMGC90_GIT_URL }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

- The docs job runs `pip install -e .` which configures CMake; CMake now hard-fails when `LMGC90_GIT_URL` isn't set (added in the Windows bring-up to read the LMGC90 source URL from a GitHub secret).
- Adds `LMGC90_GIT_URL: \${{ secrets.LMGC90_GIT_URL }}` to the docs job-level env, mirroring how `build.yml` and `release.yml` already do it.
- Fixes the failures at https://github.com/BlockResearchGroup/compas_lmgc90/actions/runs/25183489091/job/73834549715 (and the same failure on tag pushes since the docs workflow also fires on `tags: v*`).

## Test plan

- [ ] CI: docs workflow on this PR's push event should reach the editable install successfully now (FetchContent will clone LMGC90, then docs build proceeds).
- [ ] After merge, `docs` workflow on `main` push and on `v*` tag push should both go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)