### PR TITLE
Proper LMGC90 memory management: clean all modules + auto-managed Solver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `tests/test_reinit.py`: regression test for the "Rhino crashes the
+  second time you run the script" bug. Exercises both
+  `LMGC90Solver().initialize().finalize()` cycles in a loop (low-level,
+  no `compas_dem` needed — runs in cibuildwheel's slim test env) and
+  the full `Solver(model)` lifecycle (gated on `compas_dem`).
+- `Solver.__enter__` / `Solver.__exit__`: context-manager support, so
+  `with Solver(model) as solver: solver.run(...)` finalizes
+  deterministically at scope exit even on exceptions.
+- `Solver.__del__`: GC-time finalize backstop. The C++ destructor
+  already finalizes when the bound `LMGC90Solver` is collected, but
+  this lets early Python-level finalize keep up with re-instantiation
+  patterns (Rhino, Jupyter, long-lived services).
+
 ### Changed
+
+- `wrap_lmgc90_compas.f90`: extended the wrapper's `finalize()` so it
+  cleans every LMGC90 module the wrapper touches, not just five of
+  them. Previously cleaned: `PRPRx`, `POLYR`, `RBDY3`, `tact_behav`,
+  `bulk_behav`. Now also cleans `nlgs_3D` (solver `this` ledger and
+  scratch arrays — the actual culprit for second-run crashes, since
+  its `this` array holds adjacency to PRPRx contacts that *were*
+  cleaned, leaving dangling references), `models` (`modelz`/`ppset`
+  arrays from the materials chain), `postpro_3D` (file unit handles
+  and energy accumulators — no-op when postpro isn't started), and
+  `overall` (entity registry, NSTEP, time, every global config flag).
+  Cleanup order is consumers-first / providers-last: PRPRx → nlgs_3D
+  → POLYR → RBDY3 → tact_behav/bulk_behav → models → postpro_3D →
+  overall.
+- `wrap_lmgc90_compas.f90:initialize()`: now calls the same cleanup
+  helper as its first action. Defense-in-depth — even when a previous
+  Solver instance's `__del__` ran late (or not at all, on interpreter
+  shutdown), the next `initialize()` starts on a truly clean slate.
+  This is what makes `Solver(...)` re-instantiation safe in long-lived
+  processes like Rhino's ScriptEditor without the user having to call
+  `finalize()` themselves.
+- `Solver.finalize()`: now idempotent. Safe to call multiple times,
+  safe to call on a partially-constructed instance.
+- `[tool.cibuildwheel] test-command`: extended from a single-line
+  import smoke test to a list that also runs the new reinit tests
+  (`test_reinit_lowlevel` + `test_reinit_lowlevel_implicit_finalize`)
+  on every wheel. A regressed wrapper that crashes on second-init
+  fails the wheel build, not just at user runtime.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `finalize()` themselves.
 - `Solver.finalize()`: now idempotent. Safe to call multiple times,
   safe to call on a partially-constructed instance.
+- `Solver.__init__`: only creates `./OUTBOX/` when `debug=True`. The
+  Fortran wrapper only writes diagnostics there inside `if(debug)`
+  blocks, so the previous unconditional `Path("./OUTBOX").mkdir(...)`
+  was creating an empty directory for nothing — and under Rhino's
+  ScriptEditor, where the process cwd is unpredictable (often
+  somewhere users can't write), it could fail outright.
 - `[tool.cibuildwheel] test-command`: extended from a single-line
   import smoke test to a list that also runs the new reinit tests
   (`test_reinit_lowlevel` + `test_reinit_lowlevel_implicit_finalize`)

--- a/docs/examples/dem_of_an_arch_rhino.py
+++ b/docs/examples/dem_of_an_arch_rhino.py
@@ -1,0 +1,100 @@
+#! python 3
+# r: compas_lmgc90>=0.1.8
+# r: compas_dem
+# r: numpy
+"""
+Run an arch DEM simulation with LMGC90 and bake the deformed blocks
+into the active Rhino document.
+
+Paste this whole script into Rhino 8's ScriptEditor (Tools > ScriptEditor)
+and run it. The first run downloads compas_lmgc90 and its dependencies
+into Rhino's CPython environment via the `# r:` directive at the top.
+Subsequent runs reuse the cached install.
+
+Memory management note: there is no ``solver.finalize()`` call below
+and no ``with`` block. Both are optional from compas_lmgc90 0.1.8 on —
+the wrapper's ``initialize`` defensively resets every LMGC90 module's
+state at the start of each run, so re-running this script in Rhino's
+persistent ScriptEditor session is safe by construction.
+"""
+
+import numpy as np
+import scriptcontext as sc
+import Rhino
+import Rhino.Geometry as rg
+
+from compas_dem.models import BlockModel
+from compas_dem.templates import ArchTemplate
+
+from compas_lmgc90.solver import Solver
+
+# =============================================================================
+# Build the arch (same template + scaling as docs/examples/dem_of_an_arch.py)
+# =============================================================================
+
+template = ArchTemplate(rise=3, span=10, thickness=0.5, depth=0.5, n=20)
+meshes = template.blocks()
+
+for block in meshes:
+    centroid = block.centroid()
+    block.translate([-centroid[0], -centroid[1], -centroid[2]])
+    block.scale(90.0 / 100.0)
+    block.translate(centroid)
+
+model = BlockModel.from_boxes(meshes)
+
+# =============================================================================
+# Run the simulation — plain imperative form, no `with`, no finalize().
+# Re-running this script in the same Rhino session is safe.
+# =============================================================================
+
+solver = Solver(model, density=2750.0, debug=False)
+solver.set_supports(z_threshold=0.4)
+solver.apply_velocity(
+    block_index=10,
+    component="Vz",
+    value=np.array([[0.0, 0.5, 1.0], [0.0, 0.0, 1e-2]]),
+)
+solver.contact_law("IQS_CLB", 0.35)
+
+solver.preprocess()
+solver.run(nb_steps=100)
+
+# =============================================================================
+# Bake the post-solve blocks into Rhino
+# =============================================================================
+
+doc = sc.doc
+
+layer_name = "compas_lmgc90"
+layer_index = doc.Layers.FindByFullPath(layer_name, -1)
+if layer_index < 0:
+    layer = Rhino.DocObjects.Layer()
+    layer.Name = layer_name
+    layer_index = doc.Layers.Add(layer)
+
+attrs = Rhino.DocObjects.ObjectAttributes()
+attrs.LayerIndex = layer_index
+
+for compas_mesh in solver.trimeshes:
+    rhino_mesh = rg.Mesh()
+
+    vertices, faces = compas_mesh.to_vertices_and_faces(True)
+    for x, y, z in vertices:
+        rhino_mesh.Vertices.Add(x, y, z)
+    for face in faces:
+        if len(face) == 3:
+            rhino_mesh.Faces.AddFace(face[0], face[1], face[2])
+        elif len(face) == 4:
+            rhino_mesh.Faces.AddFace(face[0], face[1], face[2], face[3])
+        else:
+            for i in range(1, len(face) - 1):
+                rhino_mesh.Faces.AddFace(face[0], face[i], face[i + 1])
+
+    rhino_mesh.Normals.ComputeNormals()
+    rhino_mesh.Compact()
+
+    doc.Objects.AddMesh(rhino_mesh, attrs)
+
+doc.Views.Redraw()
+print(f"Baked {len(solver.trimeshes)} blocks onto layer '{layer_name}'.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,11 +140,19 @@ build-verbosity = 3
 test-requires = ["numpy", "compas", "compas_dem", "pytest"]
 # Import smoke test that actually loads _lmgc90.pyd — this is the whole
 # point of shipping a Windows wheel and a green CI run is meaningless if
-# `import _lmgc90` raises a DLL-load error. NOT wrapped in `|| echo`:
-# any failure must fail CI loudly. cibuildwheel joins list-form
-# test-command entries with `&&`, so a trailing `|| echo skip` on a
-# second entry would mask this one too — keep test-command single-step.
-test-command = "python -c \"import compas_lmgc90; import compas_lmgc90._lmgc90; print('compas_lmgc90', compas_lmgc90.__version__, 'imported OK')\""
+# `import _lmgc90` raises a DLL-load error. The reinit test is the
+# regression guard for the "Rhino crashes the second time you run the
+# script" class of bug: it instantiates LMGC90Solver multiple times in
+# the same process and would segfault if our wrapper's clean_memory
+# plumbing regressed. NOT wrapped in `|| echo` — any failure must fail
+# CI loudly. cibuildwheel joins list-form test-command entries with
+# `&&`, so a trailing `|| echo skip` on a later entry would mask earlier
+# failures too.
+test-command = [
+    "python -c \"import compas_lmgc90; import compas_lmgc90._lmgc90; print('compas_lmgc90', compas_lmgc90.__version__, 'imported OK')\"",
+    "python -m pytest {project}/tests/test_reinit.py::test_reinit_lowlevel -v",
+    "python -m pytest {project}/tests/test_reinit.py::test_reinit_lowlevel_implicit_finalize -v",
+]
 # LMGC90_GIT_URL holds the (private) GitLab URL with credentials. CMake
 # reads it during configure to clone LMGC90 via FetchContent. On Linux,
 # cibuildwheel runs inside a Docker container that doesn't inherit the

--- a/src/compas_lmgc90/solver.py
+++ b/src/compas_lmgc90/solver.py
@@ -72,7 +72,12 @@ class Solver:
         # In debug mode, the OUTBOX directory must exist...
         outbox = Path("./OUTBOX")
         outbox.mkdir(exist_ok=True)
-        # Create LMGC90 solver instance
+        # Create LMGC90 solver instance.
+        # The wrapped Fortran initialize() defensively resets every LMGC90
+        # module's state first (PRPRx/POLYR/RBDY3/tact_behav/bulk_behav/
+        # models/nlgs_3D/postpro/overall), so re-instantiating Solver in a
+        # long-lived process (Rhino's ScriptEditor, Jupyter, a service)
+        # works without an explicit finalize() from the previous instance.
         self.lmgc90 = _lmgc90.LMGC90Solver()
         self.lmgc90.initialize(dt, theta, debug)
 
@@ -541,5 +546,39 @@ class Solver:
         return contact_data
 
     def finalize(self):
-        """Finalize and cleanup the LMGC90 solver."""
-        self.lmgc90.finalize()
+        """Release LMGC90's process-global Fortran state held by this solver.
+
+        Calling this explicitly is optional. The C++ ``LMGC90Solver``
+        destructor calls ``lmgc90_finalize`` automatically when the
+        underlying object is collected (which happens when this Solver
+        is collected, since ``self.lmgc90`` is the only strong reference
+        the Python side holds), and is idempotent — finalizing an
+        already-finalized solver is a no-op.
+
+        It is safe to call multiple times.
+        """
+        if getattr(self, "lmgc90", None) is not None:
+            self.lmgc90.finalize()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        # `with Solver(model) as solver: ...` finalizes deterministically
+        # at scope exit, regardless of whether the body raised.
+        self.finalize()
+        return False
+
+    def __del__(self):
+        # Backstop for GC-driven cleanup. The C++ class already finalizes
+        # in its destructor when the bound LMGC90Solver goes away, so this
+        # is here purely so an early Python-level finalize lets Solver
+        # consumers be re-instantiated immediately, without waiting on
+        # the GC. Anything raising from a finalizer is suppressed —
+        # interpreter shutdown is a hostile environment and the C++
+        # destructor will still run.
+        try:
+            if getattr(self, "lmgc90", None) is not None:
+                self.lmgc90.finalize()
+        except Exception:
+            pass

--- a/src/compas_lmgc90/solver.py
+++ b/src/compas_lmgc90/solver.py
@@ -69,9 +69,16 @@ class Solver:
             # Single density for all blocks
             self.densities = [float(density)] * len(self.trimeshes)
 
-        # In debug mode, the OUTBOX directory must exist...
-        outbox = Path("./OUTBOX")
-        outbox.mkdir(exist_ok=True)
+        # OUTBOX is the working directory LMGC90 writes its diagnostic
+        # dumps to (out_bodies, dof, vloc_rloc, etc.). The Fortran
+        # wrapper guards every one of those writes behind ``if(debug)``,
+        # so the directory is only ever consulted when debug=True.
+        # Don't create it otherwise — under Rhino's ScriptEditor the
+        # process cwd is unpredictable (often somewhere users can't
+        # write), and silently spawning an empty OUTBOX/ wherever
+        # someone runs the script is a footgun.
+        if debug:
+            Path("./OUTBOX").mkdir(exist_ok=True)
         # Create LMGC90 solver instance.
         # The wrapped Fortran initialize() defensively resets every LMGC90
         # module's state first (PRPRx/POLYR/RBDY3/tact_behav/bulk_behav/

--- a/src/wrap_lmgc90_compas.f90
+++ b/src/wrap_lmgc90_compas.f90
@@ -67,7 +67,8 @@ module wrap_lmgc90_compas
                       time_increment         , &
                       display_time           , &
                       Updt_time_begin        , &
-                      get_NSTEP
+                      get_NSTEP              , &
+                      overall_clean_memory   ! resets entity registry, NSTEP, time, global flags
 
 
   use bulk_behaviour, only : set_nb_bulks        , &
@@ -156,13 +157,20 @@ module wrap_lmgc90_compas
                       quick_scramble_nlgs_3D        => quick_scramble_nlgs       , &
                       RnodHRloc_nlgs_3D             => RnodHRloc_nlgs            , &
                       update_tact_behav_nlgs_3D     => update_tact_behav_nlgs    , &
-                      nullify_entitylist_nlgs_3D    => nullify_entitylist_nlgs
+                      nullify_entitylist_nlgs_3D    => nullify_entitylist_nlgs   , &
+                      clean_memory_nlgs_3D          => clean_memory                ! solver `this` ledger + scratch arrays
 
   use postpro_3D, only : init_postpro_command_3D       => init_postpro_command      , &
                          start_postpro_3D              => start_postpro             , &
                          messages_for_users_3D         => messages_for_users        , &
                          postpro_during_computation_3D => postpro_during_computation, &
-                         close_postpro_files_3D        => close_postpro_files
+                         close_postpro_files_3D        => close_postpro_files       , &
+                         clean_memory_postpro_3D                                       ! file unit handles, energy accumulators
+
+  ! `models` is used transitively by RBDY3/POLYR through the bulk_behav/ppset
+  ! chain; it owns its own `modelz`/`ppset` allocations that don't otherwise
+  ! get cleaned. Aliased to avoid name clash with bulk/tact_behav clean_memory.
+  use models, only : clean_memory_models => clean_memory
 
   implicit none
 
@@ -259,10 +267,58 @@ contains
   ! first : some simple functions to run a simulation !
   ! ------------------------------------------------- !
 
+  !> Tear down every LMGC90 module state we touch, in reverse-dependency
+  !> order (consumers first, providers last). Used both at finalize-time
+  !> and defensively at the START of initialize, so even when a caller
+  !> drops the previous Solver instance without explicit finalize (the
+  !> usual Python/Rhino case where the destructor timing is at the
+  !> garbage collector's discretion), the next initialize starts on a
+  !> truly clean slate.
+  !>
+  !> Order rationale:
+  !>   1. PRPRx — contact ledger references POLYR + RBDY3 entities.
+  !>   2. nlgs_3D — its `this` array points at PRPRx entries; clean
+  !>      AFTER PRPRx so we don't briefly hold dangling refs, and the
+  !>      deallocate sequence is always upstream-then-downstream-clean.
+  !>   3. POLYR — contactor geometry that lived on RBDY3 bodies.
+  !>   4. RBDY3 — the bodies themselves.
+  !>   5. tact_behav / bulk_behav — registered behaviors and bulks.
+  !>   6. models — modelz/ppset arrays from the materials chain.
+  !>   7. postpro_3D — file unit handles (no-op if postpro never started).
+  !>   8. overall — entity registry, NSTEP, time, every global flag.
+  !>      Last because every module above can register entities into it.
+  subroutine reset_all_state()
+    implicit none
+
+    ! Wrapper-local state first.
+    call assume_is_initialized_3D(0)
+    is_detec_init    = .false.
+    detection_method = 0
+
+    ! LMGC90 module state.
+    call clean_memory_PRPRx
+    call clean_memory_nlgs_3D
+    call clean_memory_POLYR
+    call clean_memory_RBDY3
+    call clean_memory_tact_behav
+    call clean_memory_bulk_behav
+    call clean_memory_models
+    call clean_memory_postpro_3D
+    call overall_clean_memory
+
+  end subroutine reset_all_state
+
   subroutine initialize(dt, theta, with_log) bind(c, name='lmgc90_initialize')
     implicit none
     real(kind=8)        , intent(in), value :: dt, theta
     logical(kind=c_bool), intent(in), value :: with_log
+
+    ! Defensive: if a previous Solver instance left state in this process
+    ! (Python `__del__` may run late, or not at all on interpreter exit),
+    ! reset everything before our init paths run. This is what makes
+    ! `Solver(...)` re-instantiation safe in long-lived processes like
+    ! Rhino's ScriptEditor — the user never has to call finalize().
+    call reset_all_state()
 
     debug = with_log
     if( debug ) then
@@ -618,17 +674,7 @@ contains
   subroutine finalize() bind(c, name='lmgc90_finalize')
     implicit none
 
-    !nlgs 3d
-    call assume_is_initialized_3D(0)
-    is_detec_init = .false.
-    detection_method = 0
-
-    call clean_memory_PRPRx
-    call clean_memory_POLYR
-    call clean_memory_RBDY3
-
-    call clean_memory_tact_behav
-    call clean_memory_bulk_behav
+    call reset_all_state()
 
   end subroutine finalize
 

--- a/tests/test_reinit.py
+++ b/tests/test_reinit.py
@@ -1,0 +1,80 @@
+"""Regression test: re-initializing LMGC90 in the same process must not crash.
+
+This is the test that catches the "Rhino crashes the second time you run the
+script" class of bug. LMGC90 is a stateful Fortran library — without proper
+clean_memory plumbing in our wrapper's initialize/finalize, a second run on
+already-allocated module state segfaults.
+
+We test at two layers:
+
+1. The lowest-level wrapper: ``LMGC90Solver().initialize(...).finalize()`` in
+   a loop. Doesn't need any geometry, doesn't need ``compas_dem`` (which is
+   why this test runs in cibuildwheel's slim test env). If this segfaults,
+   the test process dies and the whole test fails the run.
+
+2. The high-level ``Solver(model)`` lifecycle (skipped if ``compas_dem`` isn't
+   importable, same convention as ``test_placeholder.py``).
+"""
+
+import pytest
+
+from compas_lmgc90._lmgc90 import LMGC90Solver
+
+
+def test_reinit_lowlevel():
+    """Re-instantiating ``LMGC90Solver`` 5 times in one process must not crash."""
+    for _ in range(5):
+        s = LMGC90Solver()
+        s.initialize(1e-2, 0.5, False)
+        s.finalize()
+        del s
+
+
+def test_reinit_lowlevel_implicit_finalize():
+    """Drop the solver without explicit finalize() — defensive reset on the
+    next ``initialize`` must still produce a clean run."""
+    for _ in range(5):
+        s = LMGC90Solver()
+        s.initialize(1e-2, 0.5, False)
+        # No explicit finalize. The C++ destructor finalizes when `s` is
+        # collected on the next loop iteration; the next initialize() also
+        # defensively resets state regardless.
+        del s
+
+
+# --------------------------------------------------------------------------- #
+# High-level test (gated on compas_dem availability — same as test_placeholder)
+# --------------------------------------------------------------------------- #
+
+try:
+    from compas_dem.models import BlockModel
+    from compas_dem.templates import ArchTemplate
+    _HAS_COMPAS_DEM = True
+except ImportError:
+    _HAS_COMPAS_DEM = False
+
+
+@pytest.mark.skipif(
+    not _HAS_COMPAS_DEM,
+    reason="compas_dem not importable (likely compas_cgal API drift)",
+)
+def test_reinit_full_solver_cycle():
+    """A full Solver(model).preprocess().run().finalize() loop must repeat."""
+    from compas_lmgc90.solver import Solver
+
+    for _ in range(3):
+        template = ArchTemplate(rise=3, span=10, thickness=0.5, depth=0.5, n=10)
+        meshes = template.blocks()
+        for block in meshes:
+            centroid = block.centroid()
+            block.translate([-centroid[0], -centroid[1], -centroid[2]])
+            block.scale(0.9)
+            block.translate(centroid)
+
+        model = BlockModel.from_boxes(meshes)
+        solver = Solver(model, density=2750.0)
+        solver.set_supports(z_threshold=0.4)
+        solver.preprocess()
+        solver.run(nb_steps=2)
+        solver.finalize()
+        del solver


### PR DESCRIPTION
## Summary

Fixes the "Rhino crashes the second time you run the script" class of bug. The user does not have to call ``finalize()`` anymore — re-instantiating ``Solver`` in a long-lived Python process is safe by construction.

### Root cause

LMGC90 is stateful Fortran (module ``save`` semantics + allocatable arrays). ``wrap_lmgc90_compas.f90:finalize()`` only cleaned 5 of the 9 LMGC90 modules its ``use`` lines touch. The crash culprit was ``nlgs_3D``: its ``this`` array kept adjacency pointers to ``PRPRx`` contact entries; we cleaned ``PRPRx`` but not ``nlgs_3D``, leaving the next ``prep_nlgs()`` walking dangling references.

### Fix (Fortran wrapper)

- Add ``use`` aliases for ``clean_memory`` in ``nlgs_3D``, ``models``, ``postpro_3D``, plus ``overall_clean_memory`` in ``overall``.
- Extract a private ``reset_all_state()`` helper that calls every ``clean_memory`` in dependency order: ``PRPRx → nlgs_3D → POLYR → RBDY3 → tact_behav/bulk_behav → models → postpro_3D → overall``.
- ``finalize()`` calls it.
- ``initialize()`` calls it **first**. Defense-in-depth — even when a previous Solver instance's ``__del__`` ran late or not at all, the next ``initialize`` starts truly clean.

### Fix (Python Solver class — memory invisible to user)

- ``__del__`` as GC-time backstop (suppresses any raise — finalizers run in hostile shutdown environments).
- ``__enter__``/``__exit__`` for ``with Solver(model) as s: ...``.
- ``finalize()`` now idempotent.

### Regression test

- ``tests/test_reinit.py`` with two low-level cycles (5 iterations each, no ``compas_dem`` needed) plus a full ``Solver(model)`` cycle gated on ``compas_dem``.
- ``[tool.cibuildwheel] test-command`` now runs the low-level reinit tests on every wheel build. A regressed wrapper fails the wheel artifact, not the user runtime.

## Test plan

- [ ] CI: ``cibuildwheel on windows`` and ``cibuildwheel on manylinux`` both green for cp39–cp313.
- [ ] CI: ``test_reinit_lowlevel`` and ``test_reinit_lowlevel_implicit_finalize`` pass on every wheel.
- [ ] Manual after merge: install the new wheel in Rhino 8, run the example twice in a row in ScriptEditor — no crash.

