### PR TITLE
fix(macos): resolve OMP: Error #15 by switching to Apple Accelerate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- cibuildwheel macOS `repair-wheel-command` now includes a guard that fails
+  the build if any OpenMP runtime (`libomp`, `libgomp`, `libiomp`) ends up
+  inside the wheel. Regression guard for the issue fixed below.
+
 ### Changed
 
+- macOS BLAS/LAPACK now resolves to Apple's Accelerate framework via
+  LMGC90's built-in `BLA_VENDOR=Apple`, instead of Homebrew OpenBLAS.
+  Fixes `OMP: Error #15: Initializing libomp.dylib, but found libomp.dylib
+  already initialized` when `compas_lmgc90` is imported into a conda env
+  that already has `libomp.dylib` loaded (NumPy/SciPy/MKL). Homebrew's
+  `libopenblasp` was a threaded build linked against Homebrew's
+  `libomp.dylib`, which `delocate` then bundled into the wheel — colliding
+  with the conda runtime's copy. Apple Accelerate has no OpenMP runtime
+  dependency, so nothing libomp-related is bundled anymore.
+
 ### Removed
+
+- Homebrew OpenBLAS detection block from `CMakeLists.txt` (was forcing
+  `BLAS_LIBRARIES`/`LAPACK_LIBRARIES` to the keg path before LMGC90's
+  `BLA_VENDOR=Apple` could take effect).
+- `openblas` from the macOS `before-all` Homebrew install — only `gcc`
+  (for `gfortran-<major>`) is needed now.
 
 
 ## [0.1.8] 2026-04-30

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,26 +35,8 @@ if(APPLE AND NOT DEFINED CMAKE_C_COMPILER)
     endif()
 endif()
 
-if(APPLE AND NOT DEFINED BLAS_LIBRARIES)
-    execute_process(
-        COMMAND brew --prefix openblas
-        OUTPUT_VARIABLE HOMEBREW_OPENBLAS_PREFIX
-        OUTPUT_STRIP_TRAILING_WHITESPACE
-        ERROR_QUIET
-    )
-    if(HOMEBREW_OPENBLAS_PREFIX AND EXISTS "${HOMEBREW_OPENBLAS_PREFIX}/lib/libopenblas.dylib")
-        # OpenBLAS provides BLAS + LAPACK in a single dylib, mirroring our
-        # Windows setup. delocate (cibuildwheel's macOS repair tool) will
-        # bundle this dylib and the gfortran/gcc runtime dylibs into the
-        # wheel automatically by walking _lmgc90's load commands.
-        list(APPEND CMAKE_PREFIX_PATH "${HOMEBREW_OPENBLAS_PREFIX}")
-        set(BLAS_LIBRARIES   "${HOMEBREW_OPENBLAS_PREFIX}/lib/libopenblas.dylib"
-            CACHE FILEPATH "" FORCE)
-        set(LAPACK_LIBRARIES "${HOMEBREW_OPENBLAS_PREFIX}/lib/libopenblas.dylib"
-            CACHE FILEPATH "" FORCE)
-        message(STATUS "macOS: Auto-detected Homebrew OpenBLAS at ${HOMEBREW_OPENBLAS_PREFIX}")
-    endif()
-endif()
+# macOS uses Apple Accelerate via LMGC90's BLA_VENDOR=Apple — overriding
+# BLAS_LIBRARIES here would pull Homebrew openblas → libomp.dylib → conda libomp double-init.
 
 # ===================================================================
 # Windows: Bootstrap MinGW-w64 + OpenBLAS before project()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,12 +119,12 @@ wheel.exclude = [
     "share/**",
 ]
 
-# macOS: compilers + BLAS are auto-detected by CMakeLists.txt's
-# Apple/Homebrew block (gcc-<major> / openblas keg via `brew --prefix`).
-# We deliberately do NOT pin CMAKE_<LANG>_COMPILER from scikit-build here
-# because that would shadow the auto-detection; the previous override
-# mixed clang++ (Apple libc++) with Homebrew gfortran (Homebrew libgcc_s),
-# which could link but was a runtime ABI minefield.
+# macOS: compilers are auto-detected by CMakeLists.txt's Apple/Homebrew
+# block (gcc-<major> via `brew --prefix`). We deliberately do NOT pin
+# CMAKE_<LANG>_COMPILER from scikit-build here because the previous
+# override mixed clang++ (Apple libc++) with Homebrew gfortran (Homebrew
+# libgcc_s), which could link but was a runtime ABI minefield. BLAS comes
+# from Apple Accelerate (driven by LMGC90's BLA_VENDOR=Apple).
 
 [tool.scikit-build.cmake.define]
 CMAKE_POLICY_DEFAULT_CMP0135 = "NEW"
@@ -171,27 +171,24 @@ skip = ["*_i686", "*-musllinux_*", "*-win32", "pp*", "cp36-*", "cp37-*", "cp38-*
 before-all = "dnf install -y gcc-gfortran openblas-devel lapack-devel"
 environment = { CMAKE_BUILD_PARALLEL_LEVEL = "2", LMGC90_GIT_URL = "$LMGC90_GIT_URL" }
 
-# macOS: install Homebrew gcc (provides gfortran-<major>) + openblas in
-# before-all; CMakeLists.txt auto-discovers them via `brew --prefix`.
-# delocate (cibuildwheel's default macOS repair-wheel-command) walks
-# _lmgc90.so's load commands and bundles libgfortran/libgcc_s/libstdc++/
-# libquadmath/libopenblas dylibs into the wheel automatically — no
-# equivalent of our Windows manual-bundle dance is needed.
+# macOS: BLAS/LAPACK comes from Apple's Accelerate framework (resolved
+# via LMGC90's BLA_VENDOR=Apple), so we only need Homebrew gcc for the
+# Fortran compiler — no openblas brew install. Delocate still bundles
+# libgfortran/libgcc_s/libstdc++/libquadmath but no libomp.dylib.
 #
-# We target arm64 only and pin the GitHub runner to macos-14 (see
-# build.yml / release.yml) — Homebrew bottles match the runner's macOS
-# version, and on `macos-latest` (currently macos-15) every Homebrew
-# dylib (libgfortran/libquadmath/libstdc++/libomp/libopenblas) reports
-# a 15.0 minimum target. Pinning to macos-14 gets us bottles targeting
-# 14.0, so the wheel runs on macOS 14 (Sonoma) and 15 (Sequoia). x86_64
-# wheels would need a separate macos-13 entry — add if Intel users ask.
-#
-# MACOSX_DEPLOYMENT_TARGET must match (or be ≥) the minimum target of
-# every dylib delocate bundles. Keep in sync with the runner label.
+# arm64-only, pinned to macos-14 so Homebrew bottles target 14.0 — must
+# match MACOSX_DEPLOYMENT_TARGET.
 [tool.cibuildwheel.macos]
 archs = ["arm64"]
-before-all = "brew install gcc openblas"
+before-all = "brew install gcc"
 environment = { CMAKE_BUILD_PARALLEL_LEVEL = "2", LMGC90_GIT_URL = "$LMGC90_GIT_URL", MACOSX_DEPLOYMENT_TARGET = "14.0" }
+# Default delocate, plus a guard that fails if any OpenMP runtime slipped
+# back into the wheel (the v0.1.8 regression that produced OMP: Error #15
+# in conda envs with NumPy/MKL preloading libomp).
+repair-wheel-command = [
+    "delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}",
+    "python -c \"import sys, zipfile, glob, os; whl=sorted(glob.glob(os.path.join('{dest_dir}','*.whl')))[-1]; bad=[n for n in zipfile.ZipFile(whl).namelist() if any(s in n.lower() for s in ('libomp','libgomp','libiomp'))]; sys.exit('OpenMP runtime in wheel: '+repr(bad)) if bad else print('OpenMP-runtime guard: clean')\"",
+]
 
 # Windows: CMake bootstrap fetches MinGW-w64 + OpenBLAS automatically.
 # delvewheel bundles the OpenBLAS DLL into the wheel.


### PR DESCRIPTION
## Summary

- macOS wheels were bundling `libomp.dylib` via Homebrew's threaded `libopenblasp`, colliding with the `libomp.dylib` that conda's NumPy/SciPy/MKL preload — `OMP: Error #15: Initializing libomp.dylib, but found libomp.dylib already initialized`.
- LMGC90's own CMake already sets `BLA_VENDOR=Apple` to drive `find_package(LAPACK)` onto Apple's Accelerate framework. Our top-level CMake was pre-setting `BLAS_LIBRARIES`/`LAPACK_LIBRARIES` to Homebrew openblas and shadowing that. Deleting the override hands BLAS to Accelerate, which ships with the OS and has no OpenMP runtime dependency.
- New `repair-wheel-command` guard fails the macOS build if any `libomp`/`libgomp`/`libiomp` ever lands back in the wheel — regression protection.

## Diagnostic evidence

Mach-O LC_LOAD_DYLIB inspection of the v0.1.8 macOS arm64 wheel confirmed the dependency chain:

```
_lmgc90.cpython-312-darwin.so
  → @loader_path/.dylibs/libopenblasp-r0.3.33.dylib
libopenblasp-r0.3.33.dylib
  → @loader_path/libomp.dylib   ← bundled, collides with conda's libomp
```

Apple Accelerate breaks this chain: no openblas, no libomp.

## Changes

- `CMakeLists.txt`: drop the 20-line Homebrew openblas detection block on macOS (was forcing `BLAS_LIBRARIES`/`LAPACK_LIBRARIES` before LMGC90's `BLA_VENDOR=Apple` could resolve to Accelerate).
- `pyproject.toml`: drop `openblas` from `[tool.cibuildwheel.macos] before-all` (only `gcc` for `gfortran-<major>` is needed); add a `repair-wheel-command` that runs default `delocate-wheel` then asserts no OpenMP runtime is in the wheel.
- `CHANGELOG.md`: documented under `Unreleased`.

Linux and Windows code paths are deliberately unchanged — the reported `OMP: Error #15` is LLVM-libomp-specific and doesn't reproduce on those platforms (their `libgomp` is GNU OpenMP, a different runtime).

## Test plan

- [x] Windows local rebuild produces a wheel byte-identical (within 1 byte) to v0.1.8 — confirms macOS-only change.
- [x] Windows runs an 80-block end-to-end smoke test (`temp/debug/trial_run.py`) on baseline and post-fix — both pass.
- [ ] macOS wheel built by CI on this branch passes the new in-wheel libomp guard automatically.
- [ ] Install the macOS arm64 artifact wheel from this PR's CI run into a `carbcomn-core` conda env on a macOS arm64 machine and run `trial.py` — confirm `OMP: Error #15` is gone.
- [ ] Existing `tests/test_reinit.py` lifecycle tests still pass on macOS in CI.